### PR TITLE
Binary data logging instead of CSV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,19 +319,37 @@ client = abb.MotionProgramExecClient(base_url="http://127.0.0.1:80")
 # Execute both motion programs simultaneously
 log_results = client.execute_multimove_motion_program([mp,mp2])
 
-# Write log csv to file
-with open("log.csv","wb") as f:
-   f.write(log_results)
-
-# Or convert to string and use in memory
-log_results_str = log_results.decode('ascii')
-print(log_results_str)
-
+# log_results.data is a numpy array
+import matplotlib.pyplot as plt
+import matplotlib.ticker as plt_ticker
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,2:8])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[2:8] + ["cmdnum"])
+ax1.set_title("Robot 1 joint motion")
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,8:])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[8:] + ["cmdnum"])
+ax1.set_title("Robot 2 joint motion")
+plt.show()
 ```
 
 Multi-Move example using relative work object:
 
 ```python
+# Multi-Move example using relative robot end effector poses
+
 import abb_motion_program_exec_client as abb
 
 
@@ -350,7 +368,7 @@ mp = abb.MotionProgram(tool=my_tool,wobj=my_wobj)
 mp.MoveAbsJ(abb.jointtarget([5,-20,30,27,-11,172],[0]*6),abb.v1000,abb.fine)
 mp.WaitTime(0.1)
 mp.MoveJ(t1,abb.v1000,abb.fine)
-mp.MoveL(t1,abb.v1000,abb.fine)
+mp.MoveJ(t1,abb.v1000,abb.fine)
 mp.MoveL(t1,abb.v1000,abb.fine)
 
 # Fill motion program for T_ROB2. Both programs must have
@@ -375,13 +393,30 @@ client = abb.MotionProgramExecClient(base_url="http://127.0.0.1:80")
 # Execute both motion programs simultaneously
 log_results = client.execute_multimove_motion_program([mp,mp2])
 
-# Write log csv to file
-with open("log.csv","wb") as f:
-   f.write(log_results)
-
-# Or convert to string and use in memory
-log_results_str = log_results.decode('ascii')
-print(log_results_str)
+# log_results.data is a numpy array
+import matplotlib.pyplot as plt
+import matplotlib.ticker as plt_ticker
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,2:8])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[2:8] + ["cmdnum"])
+ax1.set_title("Robot 1 joint motion")
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,8:])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[8:] + ["cmdnum"])
+ax1.set_title("Robot 2 joint motion")
+plt.show()
 
 ```
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -50,10 +50,17 @@ print(mp.get_program_rapid())
 client = abb.MotionProgramExecClient(base_url="http://127.0.0.1:80")
 log_results = client.execute_motion_program(mp)
 
-# Write log csv to file
-#with open("log.csv","wb") as f:
-#    f.write(log_results)
-
-# Or convert to string and use in memory
-log_results_str = log_results.decode('ascii')
-print(log_results_str)
+# log_results.data is a numpy array
+import matplotlib.pyplot as plt
+import matplotlib.ticker as plt_ticker
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,2:])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[2:] + ["cmdnum"])
+ax1.set_title("Joint motion")
+plt.show()

--- a/examples/multimove_example.py
+++ b/examples/multimove_example.py
@@ -43,12 +43,29 @@ client = abb.MotionProgramExecClient(base_url="http://127.0.0.1:80")
 # Execute both motion programs simultaneously
 log_results = client.execute_multimove_motion_program([mp,mp2])
 
-# Write log csv to file
-with open("log.csv","wb") as f:
-   f.write(log_results)
-
-# Or convert to string and use in memory
-log_results_str = log_results.decode('ascii')
-print(log_results_str)
+# log_results.data is a numpy array
+import matplotlib.pyplot as plt
+import matplotlib.ticker as plt_ticker
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,2:8])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[2:8] + ["cmdnum"])
+ax1.set_title("Robot 1 joint motion")
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,8:])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[8:] + ["cmdnum"])
+ax1.set_title("Robot 2 joint motion")
+plt.show()
 
 

--- a/examples/multimove_relative_example.py
+++ b/examples/multimove_relative_example.py
@@ -18,7 +18,7 @@ mp = abb.MotionProgram(tool=my_tool,wobj=my_wobj)
 mp.MoveAbsJ(abb.jointtarget([5,-20,30,27,-11,172],[0]*6),abb.v1000,abb.fine)
 mp.WaitTime(0.1)
 mp.MoveJ(t1,abb.v1000,abb.fine)
-mp.MoveL(t1,abb.v1000,abb.fine)
+mp.MoveJ(t1,abb.v1000,abb.fine)
 mp.MoveL(t1,abb.v1000,abb.fine)
 
 # Fill motion program for T_ROB2. Both programs must have
@@ -43,12 +43,29 @@ client = abb.MotionProgramExecClient(base_url="http://127.0.0.1:80")
 # Execute both motion programs simultaneously
 log_results = client.execute_multimove_motion_program([mp,mp2])
 
-# Write log csv to file
-with open("log.csv","wb") as f:
-   f.write(log_results)
-
-# Or convert to string and use in memory
-log_results_str = log_results.decode('ascii')
-print(log_results_str)
+# log_results.data is a numpy array
+import matplotlib.pyplot as plt
+import matplotlib.ticker as plt_ticker
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,2:8])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[2:8] + ["cmdnum"])
+ax1.set_title("Robot 1 joint motion")
+fig, ax1 = plt.subplots()
+lns1 = ax1.plot(log_results.data[:,0], log_results.data[:,8:])
+ax1.set_xlabel("Time (s)")
+ax1.set_ylabel("Joint angle (deg)")
+ax2 = ax1.twinx()
+lns2 = ax2.plot(log_results.data[:,0], log_results.data[:,1], '-k')
+ax2.set_ylabel("Command number")
+ax2.set_yticks(range(-1,int(max(log_results.data[:,1]))+1))
+ax1.legend(lns1 + lns2, log_results.column_headers[8:] + ["cmdnum"])
+ax1.set_title("Robot 2 joint motion")
+plt.show()
 
 

--- a/robot_multimove/HOME/motion_program_multimove_exec.mod
+++ b/robot_multimove/HOME/motion_program_multimove_exec.mod
@@ -1,6 +1,6 @@
 MODULE motion_program_exec
 
-    CONST num motion_program_file_version:=10005;
+    CONST num motion_program_file_version:=10006;
 
     PERS motion_program_state_type motion_program_state{2};
 
@@ -25,12 +25,16 @@ MODULE motion_program_exec
     PERS tasks task_list{2}:=[["T_ROB1"],["T_ROB2"]];
 
     VAR syncident sync1;
-
+    
+    VAR errnum ERR_INVALID_MP_VERSION := -1;
+    VAR errnum ERR_INVALID_MP_FILE := -1;
 
     PROC main()
         VAR zonedata z:=fine;
         VAR string taskname;
         VAR string filename;
+        BookErrNo ERR_INVALID_MP_VERSION;
+        BookErrNo ERR_INVALID_MP_FILE;
         SyncMoveOn sync1,task_list;
         taskname:=GetTaskName();
         IF taskname="T_ROB1" THEN
@@ -76,19 +80,23 @@ MODULE motion_program_exec
         ENDIF
 
         IF ver<>motion_program_file_version THEN
-            RAISE ERR_WRONGVAL;
+            ErrWrite"Invalid Motion Program","Invalid motion program file version";
+            RAISE ERR_INVALID_MP_VERSION;
         ENDIF
 
         IF NOT try_motion_program_read_td(mtool) THEN
-            RAISE ERR_FILESIZE;
+            ErrWrite"Invalid Motion Program Tool","Invalid motion program tool";
+            RAISE ERR_INVALID_MP_FILE;
         ENDIF
         
         IF NOT try_motion_program_read_wd(mwobj) THEN
-            RAISE ERR_FILESIZE;
+            ErrWrite"Invalid Motion Program Wobj","Invalid motion program wobj";
+            RAISE ERR_INVALID_MP_FILE;
         ENDIF
 
         IF NOT try_motion_program_read_string(timestamp) THEN
-            RAISE ERR_FILESIZE;
+            ErrWrite"Invalid Motion Program Timestamp","Invalid motion program timestamp";
+            RAISE ERR_INVALID_MP_FILE;
         ENDIF
 
         motion_program_state{task_ind}.program_timestamp:=timestamp;


### PR DESCRIPTION
Use binary data logging format for logging real-time joint motion. This should be more efficient and have higher precision than existing text CSV based data format. The execute_motion_program() function now returns a tuple containing timestamp, column_headers, and data. data is a numpy array.